### PR TITLE
html: rewrite render as visitor

### DIFF
--- a/pkg/html/element.go
+++ b/pkg/html/element.go
@@ -5,7 +5,7 @@ func NewTag(name string, options ...Node) Node {
 	return Node{
 		nodeType: nodeTypeTag,
 		str1:     name,
-		data:     options,
+		children: options,
 	}
 }
 
@@ -15,6 +15,6 @@ func NewVoidTag(name string, options ...Node) Node {
 	return Node{
 		nodeType: nodeTypeVoidTag,
 		str1:     name,
-		data:     options,
+		children: options,
 	}
 }

--- a/pkg/html/many.go
+++ b/pkg/html/many.go
@@ -17,7 +17,7 @@ func ForEach[T any](items []T, view func(T) Node) Node {
 	}
 	return Node{
 		nodeType: nodeTypeMany,
-		data:     results,
+		children: results,
 	}
 }
 
@@ -31,6 +31,6 @@ func ForEach[T any](items []T, view func(T) Node) Node {
 func Combine(options ...Node) Node {
 	return Node{
 		nodeType: nodeTypeMany,
-		data:     options,
+		children: options,
 	}
 }

--- a/pkg/html/render.go
+++ b/pkg/html/render.go
@@ -1,0 +1,48 @@
+package html
+
+// renderVisitor is the core implementation of Node.Render.
+type renderVisitor struct {
+	bytes []byte
+}
+
+func (rv *renderVisitor) Tag(name string, node *Node) {
+	rv.write("<")
+	rv.write(name)
+
+	node.VisitAttributes(rv)
+
+	rv.write(">")
+
+	node.VisitChildren(rv)
+
+	rv.write("</")
+	rv.write(name)
+	rv.write(">")
+}
+
+func (rv *renderVisitor) VoidTag(name string, node *Node) {
+	rv.write("<")
+	rv.write(name)
+
+	node.VisitAttributes(rv)
+
+	rv.write(">")
+}
+
+func (rv *renderVisitor) Content(content string) {
+	rv.write(content)
+}
+
+func (rv *renderVisitor) Attribute(name string, value *string) {
+	rv.write(" ")
+	rv.write(name)
+	if value != nil {
+		rv.write("=\"")
+		rv.write(*value)
+		rv.write("\"")
+	}
+}
+
+func (rv *renderVisitor) write(str string) {
+	rv.bytes = append(rv.bytes, str...)
+}


### PR DESCRIPTION
Previously, rendering was implemented as manual walk over the sanity node tree. Now, there is a Visitor interface that manages the walk and render uses the visitor interface.

The goal of the change is to make it possible for library clients to walk the tree. For example, it would be nice to walk a form and check that the name of all inputs match what the server expects when in the form action handler.

Using dynamic dispatch when rendering slows down the render slightly. But, while adding the visitor I noticed that using any instead of []Node was causing an extra allocation for each tag. Swapping to []Node removed the extra allocation and more than made up for the cost of the dynamic dispatch.